### PR TITLE
Allow TIM2 to remap to ETH_PTP even if TIM8 is present

### DIFF
--- a/Inc/stm32f4xx_hal_tim_ex.h
+++ b/Inc/stm32f4xx_hal_tim_ex.h
@@ -159,6 +159,7 @@ typedef struct
 #elif defined(TIM8)
 #define IS_TIM_REMAP(INSTANCE, TIM_REMAP)                                 \
   ((((INSTANCE) == TIM2)  && (((TIM_REMAP) == TIM_TIM2_TIM8_TRGO)      || \
+                              ((TIM_REMAP) == TIM_TIM2_ETH_PTP)        || \
                               ((TIM_REMAP) == TIM_TIM2_USBFS_SOF)      || \
                               ((TIM_REMAP) == TIM_TIM2_USBHS_SOF)))    || \
    (((INSTANCE) == TIM5)  && (((TIM_REMAP) == TIM_TIM5_GPIO)           || \

--- a/Inc/stm32f4xx_hal_tim_ex.h
+++ b/Inc/stm32f4xx_hal_tim_ex.h
@@ -142,6 +142,7 @@ typedef struct
 #if defined(LPTIM_OR_TIM1_ITR2_RMP) && defined(LPTIM_OR_TIM5_ITR1_RMP) && defined(LPTIM_OR_TIM5_ITR1_RMP)
 #define IS_TIM_REMAP(INSTANCE, TIM_REMAP)                                 \
   ((((INSTANCE) == TIM2)  && (((TIM_REMAP) == TIM_TIM2_TIM8_TRGO)      || \
+                              ((TIM_REMAP) == TIM_TIM2_ETH_PTP) ||        \
                               ((TIM_REMAP) == TIM_TIM2_USBFS_SOF)      || \
                               ((TIM_REMAP) == TIM_TIM2_USBHS_SOF)))    || \
    (((INSTANCE) == TIM5)  && (((TIM_REMAP) == TIM_TIM5_GPIO)           || \


### PR DESCRIPTION
This aligns with the manual and 9dd5bce

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/stm32f4xx_hal_driver/blob/master/CONTRIBUTING.md) file.
